### PR TITLE
chore: fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If it doesn't speak to you or if you need custom Kirby page blueprints with cust
 
 - 🌐 Internationalization with [`@nuxtjs/i18n`](https://github.com/nuxt-modules/i18n)
 - 🏆 Motto: [“Everything is a block”](./components/Kirby/Block/) – Kirby blocks define what to render for each page
-- 🛣️ All pages are rendered by the [catch-all route](./pages/[...id].vue) by default (you can still create Nuxt pages)
+- 🛣️ All pages are rendered by the [catch-all route](./pages/[...slug].vue) by default (you can still create Nuxt pages)
 - 🌌 Use Kirby's page structure as the source of truth
 - 🫂 Kirby Query Language with [`nuxt-kql`](https://nuxt-kql.byjohann.dev)
 - 🏛 Global [site data](./plugins/site.ts) similar to Kirby's `$site`


### PR DESCRIPTION
Fix another instance of broken link to **catch-all route**. This is the last one, I swear.